### PR TITLE
add easy, med, hard, elite clues to rs api config

### DIFF
--- a/lib/configs/rs.json
+++ b/lib/configs/rs.json
@@ -64,7 +64,12 @@
         "Heist Robber Level",
         "CFP: 5 game average",
         "AF15: Cow Tipping",
-        "AF15: Rats killed after the miniquest"
+        "AF15: Rats killed after the miniquest",        
+        "Easy clue scrolls",
+        "Medium clue scrolls",
+        "Hard clue scrolls",
+        "Elite clue scrolls",
+        "Master clue scrolls"
       ],
       "skillIds": [
         {"id": 0, "name":"Attack"},


### PR DESCRIPTION
The RS lite api recently added ranks and scores for clue scroll activities, Added the missing activities to the config so it's included in the response.